### PR TITLE
FreeBoardCommentAPI의 update부분 수정, diaryDetail.mustache 에서 사진이 안나오는 부분 수정

### DIFF
--- a/src/main/java/com/example/MultiGreenMaster/api/FreeBoardCommentAPI.java
+++ b/src/main/java/com/example/MultiGreenMaster/api/FreeBoardCommentAPI.java
@@ -135,7 +135,7 @@ public class FreeBoardCommentAPI extends SessionCheckCTL {
     @PutMapping("/{id}/update")
     public ResponseEntity<String> updateComment(
             @PathVariable Long id,
-            @ModelAttribute("content") String content,  // 클라이언트로부터 content 직접 받음
+            @RequestBody String content,  // 클라이언트로부터 JSON 형식의 content를 직접 받음
             HttpSession session) {
 
         logger.info("Update comment request received for comment ID: {}", id);

--- a/src/main/resources/templates/diary/diaryDetail.mustache
+++ b/src/main/resources/templates/diary/diaryDetail.mustache
@@ -3,11 +3,10 @@
 <h1 id="diaryTitle">{{diary.title}}</h1>
 <p id="diaryAuthor">작성자: <a href="/user/{{diary.user.id}}/guestbook">{{diary.user.nickname}}</a></p>
 <p id="diaryContent">{{diary.content}}</p>
-<div id="diaryImages">
-    {{#diary.pictureBase64List}}
-        <img src="data:image/jpeg;base64,{{.}}" alt="Diary Image">
-    {{/diary.pictureBase64List}}
-</div>
+
+<!-- 이미지를 동적으로 추가하기 위한 빈 div -->
+<div id="diaryImages"></div>
+
 <p id="diaryRegdate">작성 시간: {{diary.regdate}}</p>
 
 <button id="editDiary">수정</button>
@@ -25,6 +24,37 @@
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         var diaryId = {{diary.id}}; // 서버에서 전달된 diary ID를 사용
+
+        // 다이어리 데이터를 API로 불러와 이미지 렌더링
+        fetch('/api/diaries/' + diaryId)
+        .then(response => {
+            if (!response.ok) {
+                // 게시글을 찾지 못했을 때
+                alert('존재하지 않거나 삭제된 게시글입니다.');
+                window.location.href = '/diaries'; // 다이어리 목록 페이지로 리다이렉트
+            } else {
+                return response.json();
+            }
+        })
+        .then(diary => {
+            // 다이어리 상세 페이지 내용 업데이트
+            document.getElementById('diaryTitle').textContent = diary.title;
+            document.getElementById('diaryAuthor').textContent = '작성자: ' + diary.user.nickname;
+            document.getElementById('diaryContent').textContent = diary.content;
+
+            const diaryImagesDiv = document.getElementById('diaryImages');
+            diary.pictureBase64List.forEach(imageBase64 => {
+                const imgElement = document.createElement('img');
+                imgElement.src = 'data:image/jpeg;base64,' + imageBase64;
+                imgElement.alt = 'Diary Image';
+                diaryImagesDiv.appendChild(imgElement);
+            });
+        })
+        .catch(error => {
+            console.error('Error fetching diary details:', error);
+            alert('게시글을 불러오는 도중 오류가 발생했습니다.');
+            window.location.href = '/diaries';
+        });
 
         // 게시글 수정 버튼 클릭 이벤트
         document.getElementById('editDiary').addEventListener('click', function() {


### PR DESCRIPTION
서버 사이드 렌더링이 바이너리 데이터를 동적으로 처리하지 못하여 Mustache 템플릿이 이를 바로 렌더링를 하지 못함, 따라서 클라이언트 사이드에서 이미지를 API를 통해 동적으로 가져오고, Base64 인코딩된 데이터를 사용해 img 태그에 추가하는 방식으로 문제를 해결.