### PR TITLE
admin_user.mustache 회원상세목록 페이지 추가

### DIFF
--- a/src/main/java/com/example/MultiGreenMaster/controller/PlantCTL.java
+++ b/src/main/java/com/example/MultiGreenMaster/controller/PlantCTL.java
@@ -12,4 +12,7 @@ public class PlantCTL {
     public String inputPage () {
         return "test-plant/input";
     }
+
+    @GetMapping("/adminuser")
+    public String adminuserPage () { return "test-plant/admin_user"; }
 }

--- a/src/main/resources/templates/test-plant/admin_user.mustache
+++ b/src/main/resources/templates/test-plant/admin_user.mustache
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin User Management</title>
+    <style>
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        table, th, td {
+            border: 1px solid black;
+        }
+        th, td {
+            padding: 10px;
+            text-align: left;
+        }
+    </style>
+</head>
+<body>
+<h1>Admin User Management</h1>
+
+<table id="userTable">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Login ID</th>
+        <th>Password</th>
+        <th>Password Check</th>
+        <th>Nickname</th>
+        <th>Name</th>
+        <th>Phone Number</th>
+        <th>Email</th>
+        <th>Role</th>
+        <th>Active</th>
+        <th>Actions</th>
+        <th>식물할당</th>
+    </tr>
+    </thead>
+    <tbody>
+    <!-- 사용자 데이터가 여기에 동적으로 추가됩니다 -->
+    </tbody>
+</table>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        // 사용자 리스트 Fetch API 호출
+        fetch('/api/admin/getuserlist')
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Failed to fetch user data');
+                }
+                return response.json();
+            })
+            .then(data => {
+                const userTable = document.querySelector('#userTable tbody');
+                userTable.innerHTML = '';  // 기존 내용을 지움
+
+                data.forEach(user => {
+                    const row = document.createElement('tr');
+
+                    row.innerHTML = `
+                        <td>${user.id}</td>
+                        <td><input type="text" id="loginId-${user.id}" value="${user.loginId}"></td>
+                        <td><input type="password" id="password-${user.id}" value="${user.password}"></td>
+                        <td><input type="password" id="passwordCheck-${user.id}" value="${user.passwordCheck}"></td>
+                        <td><input type="text" id="nickname-${user.id}" value="${user.nickname}"></td>
+                        <td><input type="text" id="name-${user.id}" value="${user.name}"></td>
+                        <td><input type="text" id="phonenumber-${user.id}" value="${user.phonenumber}"></td>
+                        <td><input type="text" id="email-${user.id}" value="${user.email}"></td>
+                        <td>
+                            <select name="role" id="role-${user.id}">
+                                <option value="0" ${user.role === 'USER' ? 'selected' : ''}>User</option>
+                                <option value="1" ${user.role === 'ADMIN' ? 'selected' : ''}>Admin</option>
+                            </select>
+                        </td>
+                        <td>${user.active ? 'Active' : 'Inactive'}</td>
+                        <td>
+                            <button type="button" onclick="updateUser(${user.id})">Update</button>
+                        </td>
+                        <td>식물할당</td>
+                    `;
+
+                    userTable.appendChild(row);
+                });
+            })
+            .catch(error => console.error('Error:', error));
+    });
+
+    function updateUser(userId) {
+        const userForm = {
+            id: userId,
+            loginId: document.getElementById(`loginId-${userId}`).value,
+            password: document.getElementById(`password-${userId}`).value,
+            passwordCheck: document.getElementById(`passwordCheck-${userId}`).value,
+            nickname: document.getElementById(`nickname-${userId}`).value,
+            name: document.getElementById(`name-${userId}`).value,
+            phonenumber: document.getElementById(`phonenumber-${userId}`).value,
+            email: document.getElementById(`email-${userId}`).value,
+            role: document.getElementById(`role-${userId}`).value, // role을 숫자로 전달 (0: USER, 1: ADMIN)
+            active: document.getElementById(`active-${userId}`) ? 1 : 0
+        };
+
+        fetch('/api/admin/update', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(userForm)
+        })
+        .then(response => {
+            if (response.ok) {
+                alert('User updated successfully');
+            } else {
+                alert('Failed to update user');
+            }
+        })
+        .catch(error => console.error('Error:', error));
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
1. PlantCTL 에 @GetMapping("/adminuser")로 연결시 test-plant/admin_user 연결하는 매핑 추가
2. test-plant내의 admin_user.mustache에 회원 상세 목록을 검색하는 admin페이지 추가
3. admin 페이지는 각 회원의 항목을 수정할 수 있음 ( 물론 admin 계정만 가능)